### PR TITLE
Voice Acting system improvements (#252)

### DIFF
--- a/Assembly-CSharp/Global/SFX/SFX.cs
+++ b/Assembly-CSharp/Global/SFX/SFX.cs
@@ -1643,6 +1643,7 @@ public static class SFX
             SFX.SFX_InitSystem(SFX.BattleCallback);
         }
         SFX.isSystemRun = true;
+        SFX.lastPlayedExeId = 0;
     }
 
     public static void EndDebugRoom()
@@ -1942,6 +1943,8 @@ public static class SFX
         SFX.isRunning = true;
         SFX.frameIndex = 0;
         SFX.effectPointFrame = -1;
+        if (SFX.request.exe.btl_id <= 8)
+            SFX.lastPlayedExeId = SFX.request.exe.btl_id;
         PSXTextureMgr.Reset();
         SFXMesh.DetectEyeFrameStart = -1;
         Int32 num3 = Marshal.SizeOf(SFX.request);
@@ -2521,4 +2524,6 @@ public static class SFX
     public static Int32 preventStepInOut = -1;
 
     public static Int32 effectPointFrame = -1;
+
+    public static UInt16 lastPlayedExeId = 0;
 }

--- a/Assembly-CSharp/Global/battle/battle.cs
+++ b/Assembly-CSharp/Global/battle/battle.cs
@@ -349,6 +349,7 @@ public static class battle
                                 btlsnd.ff9btlsnd_sndeffect_play(2907, 0, SByte.MaxValue, 128);
                                 btlsnd.ff9btlsnd_sndeffect_play(2908, 0, SByte.MaxValue, 128);
                                 btlsys.btl_escape_fade -= 2;
+                                BattleVoice.TriggerOnBattleInOut("Flee");
                             }
                         }
                         break;
@@ -455,7 +456,6 @@ public static class battle
                         }
                         UIManager.Battle.SetBattleFollowMessage(BattleMesages.DroppedGil, gilLost);
                     }
-                    BattleVoice.TriggerOnBattleInOut("Flee");
                     break;
             }
             if (btlsys.btl_phase != 5)

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -177,6 +177,12 @@ namespace NCalc
                 if (v1 != Int64.MinValue || v2 != Int64.MinValue)
                     args.Result = Math.Max(v1, v2);
             }
+            else if (name == "MemoriaLog" && args.Parameters.Length == 1)
+            {
+                Object result = args.Parameters[0].Evaluate();
+                Memoria.Prime.Log.Message($"[{nameof(NCalcUtility)}] Expression '{args.Parameters[0].ParsedExpression}' evaluates to '{result}' ({result.GetType().Name})");
+                args.Result = result;
+            }
         };
 
         public static EvaluateParameterHandler commonNCalcParameters = delegate (String name, ParameterArgs args)


### PR DESCRIPTION
* Add a MemoriaLog function to NCalcUtility
* Multiple audio paths for battle voice effects
* Play the voice line of the first choice automatically
* BattleVoiceEffects.txt hot loading
* Initialize more expression units for the battle voice system
* Keeping track of the last player character to act for BattleInOut voice acting
* Fix WhenFlee not working properly